### PR TITLE
fix: correct nearest current tick when current tick is below smallest

### DIFF
--- a/entities/ticklist.go
+++ b/entities/ticklist.go
@@ -189,6 +189,15 @@ func NextInitializedTickWithinOneWord(ticks []Tick, tick int, lte bool, tickSpac
 }
 
 func GetNearestCurrentTick(ticks []Tick, currentTick int) (int, error) {
+	isBelowSmallest, err := IsBelowSmallest(ticks, currentTick)
+	if err != nil {
+		return utils.MinTick, err
+	}
+
+	if isBelowSmallest {
+		return utils.MinTick, nil
+	}
+
 	tick, err := NextInitializedTick(ticks, currentTick, true)
 	if err != nil {
 		return TickIndexZero, err

--- a/entities/ticklist_test.go
+++ b/entities/ticklist_test.go
@@ -143,3 +143,37 @@ func TestNextInitializedTickWithinOneWord(t *testing.T) {
 	}
 
 }
+
+func TestGetNearestCurrentTick(t *testing.T) {
+	testCases := []struct {
+		name           string
+		ticks          []Tick
+		currenTick     int
+		expectedResult int
+		expectedError  error
+	}{
+		{
+			name:           "it should return minTicks with error when currentTick is min tick and ticks is empty",
+			ticks:          []Tick{},
+			currenTick:     utils.MinTick,
+			expectedResult: utils.MinTick,
+			expectedError:  ErrEmptyTickList,
+		},
+		{
+			name:           "it should return minTicks with no error when currentTick is min tick and ticks is not empty",
+			ticks:          []Tick{lowTick, midTick, highTick},
+			currenTick:     utils.MinTick,
+			expectedResult: utils.MinTick,
+			expectedError:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := GetNearestCurrentTick(tc.ticks, tc.currenTick)
+
+			assert.Equal(t, tc.expectedResult, result)
+			assert.ErrorIs(t, err, tc.expectedError)
+		})
+	}
+}


### PR DESCRIPTION
- https://team-kyber.slack.com/archives/C048KKJ4TPW/p1686034556194349
- https://team-kyber.slack.com/archives/C054H6WG7EV/p1686048555583889